### PR TITLE
Add network bank permissions

### DIFF
--- a/src/me/ellbristow/ChestBank/ChestBank.java
+++ b/src/me/ellbristow/ChestBank/ChestBank.java
@@ -43,6 +43,7 @@ public class ChestBank extends JavaPlugin {
     public String[] blacklist = new String[]{"8","9","10","11","51"};
     public boolean gotVault = false;
     public boolean gotEconomy = false;
+    public boolean useNetworkPerms = false;
     public vaultBridge vault;
     public double createFee;
     public double useFee;
@@ -67,8 +68,10 @@ public class ChestBank extends JavaPlugin {
         config.set("vip_limit", limits[2]);
         useWhitelist = config.getBoolean("use_whitelist", false);
         useBlacklist = config.getBoolean("use_blacklist", false);
+        useNetworkPerms = config.getBoolean("use_network_perms", false);
         config.set("use_whitelist", useWhitelist);
         config.set("use_blacklist", useBlacklist);
+        config.set("use_network_perms", useNetworkPerms);
         String whitelistString = config.getString("whitelist", "41,264,266,371");
         if (useWhitelist) {
             whitelist = whitelistString.split(",");

--- a/src/me/ellbristow/ChestBank/ChestBankListener.java
+++ b/src/me/ellbristow/ChestBank/ChestBankListener.java
@@ -44,7 +44,7 @@ public class ChestBankListener implements Listener {
                     else {
                         boolean allowed = true;
                         String network = plugin.getNetwork(block);
-                        if(plugin.useNetworkPerms == true && !player.hasPermissions("chestbank.use.network." + network))
+                        if(plugin.useNetworkPerms == true && !player.hasPermission("chestbank.use.network." + network))
                         {
                         	player.sendMessage(ChatColor.RED + "You are not allowed to use that ChestBank!");
                         	return;

--- a/src/me/ellbristow/ChestBank/ChestBankListener.java
+++ b/src/me/ellbristow/ChestBank/ChestBankListener.java
@@ -43,6 +43,12 @@ public class ChestBankListener implements Listener {
                     }
                     else {
                         boolean allowed = true;
+                        String network = plugin.getNetwork(block);
+                        if(plugin.useNetworkPerms == true && !player.hasPermissions("chestbank.use.network." + network))
+                        {
+                        	player.sendMessage(ChatColor.RED + "You are not allowed to use that ChestBank!");
+                        	return;
+                        }
                         if (plugin.gotVault && plugin.gotEconomy && plugin.useFee != 0 && !player.hasPermission("chestbank.free.use.networks")) {
                             if (plugin.vault.economy.getBalance(player.getName()) < plugin.useFee) {
                                 player.sendMessage(ChatColor.RED + "You cannot afford the transaction fee of " + ChatColor.WHITE + plugin.vault.economy.format(plugin.useFee) + ChatColor.RED + "!");
@@ -50,7 +56,6 @@ public class ChestBankListener implements Listener {
                             }
                         }
                         if (allowed) {
-                            String network = plugin.getNetwork(block);
                             DoubleChestInventory inv = plugin.chestAccounts.get(network + ">>" + player.getName());
                             if (inv != null && inv.getContents().length != 0) {
                                 plugin.openInvs.put(player.getName(), network);

--- a/src/me/ellbristow/ChestBank/ChestBankListener.java
+++ b/src/me/ellbristow/ChestBank/ChestBankListener.java
@@ -47,6 +47,7 @@ public class ChestBankListener implements Listener {
                         if(plugin.useNetworkPerms == true && !player.hasPermission("chestbank.use.network." + network))
                         {
                         	player.sendMessage(ChatColor.RED + "You are not allowed to use that ChestBank!");
+                        	event.setCancelled(true);
                         	return;
                         }
                         if (plugin.gotVault && plugin.gotEconomy && plugin.useFee != 0 && !player.hasPermission("chestbank.free.use.networks")) {


### PR DESCRIPTION
You enable the use_network_perms option in the configuration file.
So you make a chestbank on network "A".
You have the permission "chestbank.use.network.A".
You can open the chestbank.

Another player comes up.
He doesn't have the permission "chestbank.use.network.A".
He can't open the chestbank.

You disable the use_network_perms option in the configuration file.
So you make a chestbank on network "A".
You have the permission "chestbank.use.network.A".
You can open the chestbank.

Another player comes up.
He doesn't have the permission "chestbank.use.network.A".
He can open the chestbank.

Simple?
